### PR TITLE
Add missing write barriers

### DIFF
--- a/src/ruby/ext/grpc/rb_call.c
+++ b/src/ruby/ext/grpc/rb_call.c
@@ -111,14 +111,12 @@ const rb_data_type_t grpc_rb_md_ary_data_type = {
      {NULL, NULL}},
     NULL,
     NULL,
-#ifdef RUBY_TYPED_FREE_IMMEDIATELY
     /* it is unsafe to specify RUBY_TYPED_FREE_IMMEDIATELY because
      * grpc_rb_call_destroy
      * touches a hash object.
      * TODO(yugui) Directly use st_table and call the free function earlier?
      */
     0,
-#endif
 };
 
 /* Describes grpc_call struct for RTypedData */
@@ -129,9 +127,7 @@ static const rb_data_type_t grpc_call_data_type = {"grpc_call",
                                                     {NULL, NULL}},
                                                    NULL,
                                                    NULL,
-#ifdef RUBY_TYPED_FREE_IMMEDIATELY
                                                    RUBY_TYPED_FREE_IMMEDIATELY
-#endif
 };
 
 /* Error code details is a hash containing text strings describing errors */

--- a/src/ruby/ext/grpc/rb_call_credentials.c
+++ b/src/ruby/ext/grpc/rb_call_credentials.c
@@ -222,9 +222,7 @@ static rb_data_type_t grpc_rb_call_credentials_data_type = {
      {NULL, NULL}},
     NULL,
     NULL,
-#ifdef RUBY_TYPED_FREE_IMMEDIATELY
     RUBY_TYPED_FREE_IMMEDIATELY
-#endif
 };
 
 /* Allocates CallCredentials instances.

--- a/src/ruby/ext/grpc/rb_call_credentials.c
+++ b/src/ruby/ext/grpc/rb_call_credentials.c
@@ -40,7 +40,8 @@ static VALUE grpc_rb_cCallCredentials = Qnil;
  * object that is used to hold references to any objects used to create the
  * credentials. */
 typedef struct grpc_rb_call_credentials {
-  /* Holder of ruby objects involved in contructing the credentials */
+  /* Holder of ruby objects involved in contructing the credentials.
+     Must be written using RB_OBJ_WRITE for proper write barriers */
   VALUE mark;
 
   /* The actual credentials */
@@ -171,6 +172,8 @@ static int grpc_rb_call_credentials_plugin_get_metadata(
     size_t* num_creds_md, grpc_status_code* status,
     const char** error_details) {
   callback_params* params = gpr_zalloc(sizeof(callback_params));
+  // FIXME: do we need to call a gc function for this VALUE?  This
+  // callback_params doesn't have a corresponding rb_data_type_t.
   params->get_metadata = (VALUE)state;
   grpc_auth_metadata_context_copy(&context, &params->context);
   params->user_data = user_data;
@@ -222,7 +225,7 @@ static rb_data_type_t grpc_rb_call_credentials_data_type = {
      {NULL, NULL}},
     NULL,
     NULL,
-    RUBY_TYPED_FREE_IMMEDIATELY
+    RUBY_TYPED_FREE_IMMEDIATELY | RUBY_TYPED_WB_PROTECTED
 };
 
 /* Allocates CallCredentials instances.
@@ -249,7 +252,7 @@ VALUE grpc_rb_wrap_call_credentials(grpc_call_credentials* c, VALUE mark) {
   TypedData_Get_Struct(rb_wrapper, grpc_rb_call_credentials,
                        &grpc_rb_call_credentials_data_type, wrapper);
   wrapper->wrapped = c;
-  wrapper->mark = mark;
+  RB_OBJ_WRITE(rb_wrapper, &wrapper->mark, mark);
   return rb_wrapper;
 }
 
@@ -287,7 +290,7 @@ static VALUE grpc_rb_call_credentials_init(VALUE self, VALUE proc) {
     return Qnil;
   }
 
-  wrapper->mark = proc;
+  RB_OBJ_WRITE(self, &wrapper->mark, proc);
   wrapper->wrapped = creds;
   rb_ivar_set(self, id_callback, proc);
 

--- a/src/ruby/ext/grpc/rb_channel.c
+++ b/src/ruby/ext/grpc/rb_channel.c
@@ -69,6 +69,7 @@ typedef struct bg_watched_channel {
 
 /* grpc_rb_channel wraps a grpc_channel. */
 typedef struct grpc_rb_channel {
+  /* Ruby VALUE that must be written using RB_OBJ_WRITE for proper write barriers */
   VALUE credentials;
   grpc_channel_args args;
   /* The actual channel (protected in a wrapper to tell when it's safe to
@@ -188,7 +189,7 @@ static rb_data_type_t grpc_channel_data_type = {"grpc_channel",
                                                  {NULL, NULL}},
                                                 NULL,
                                                 NULL,
-                                                RUBY_TYPED_FREE_IMMEDIATELY
+                                                RUBY_TYPED_FREE_IMMEDIATELY | RUBY_TYPED_WB_PROTECTED
 };
 
 /* Allocates grpc_rb_channel instances. */
@@ -237,7 +238,7 @@ static VALUE grpc_rb_channel_init(int argc, VALUE* argv, VALUE self) {
     ch = grpc_channel_create(target_chars, insecure_creds, &wrapper->args);
     grpc_channel_credentials_release(insecure_creds);
   } else {
-    wrapper->credentials = credentials;
+    RB_OBJ_WRITE(self, &wrapper->credentials, credentials);
     if (grpc_rb_is_channel_credentials(credentials)) {
       creds = grpc_rb_get_wrapped_channel_credentials(credentials);
     } else if (grpc_rb_is_xds_channel_credentials(credentials)) {

--- a/src/ruby/ext/grpc/rb_channel.c
+++ b/src/ruby/ext/grpc/rb_channel.c
@@ -188,9 +188,7 @@ static rb_data_type_t grpc_channel_data_type = {"grpc_channel",
                                                  {NULL, NULL}},
                                                 NULL,
                                                 NULL,
-#ifdef RUBY_TYPED_FREE_IMMEDIATELY
                                                 RUBY_TYPED_FREE_IMMEDIATELY
-#endif
 };
 
 /* Allocates grpc_rb_channel instances. */

--- a/src/ruby/ext/grpc/rb_channel_args.c
+++ b/src/ruby/ext/grpc/rb_channel_args.c
@@ -36,9 +36,7 @@ static rb_data_type_t grpc_rb_channel_args_data_type = {
      {NULL, NULL}},
     NULL,
     NULL,
-#ifdef RUBY_TYPED_FREE_IMMEDIATELY
     RUBY_TYPED_FREE_IMMEDIATELY
-#endif
 };
 
 /* A callback the processes the hash key values in channel_args hash */

--- a/src/ruby/ext/grpc/rb_channel_credentials.c
+++ b/src/ruby/ext/grpc/rb_channel_credentials.c
@@ -86,9 +86,7 @@ static rb_data_type_t grpc_rb_channel_credentials_data_type = {
      {NULL, NULL}},
     NULL,
     NULL,
-#ifdef RUBY_TYPED_FREE_IMMEDIATELY
     RUBY_TYPED_FREE_IMMEDIATELY
-#endif
 };
 
 /* Allocates ChannelCredential instances.

--- a/src/ruby/ext/grpc/rb_channel_credentials.c
+++ b/src/ruby/ext/grpc/rb_channel_credentials.c
@@ -41,7 +41,8 @@ static char* pem_root_certs = NULL;
  * mark object that is used to hold references to any objects used to create
  * the credentials. */
 typedef struct grpc_rb_channel_credentials {
-  /* Holder of ruby objects involved in constructing the credentials */
+  /* Holder of ruby objects involved in constructing the credentials.
+     Must be written using RB_OBJ_WRITE for proper write barriers */
   VALUE mark;
 
   /* The actual credentials */
@@ -86,7 +87,7 @@ static rb_data_type_t grpc_rb_channel_credentials_data_type = {
      {NULL, NULL}},
     NULL,
     NULL,
-    RUBY_TYPED_FREE_IMMEDIATELY
+    RUBY_TYPED_FREE_IMMEDIATELY | RUBY_TYPED_WB_PROTECTED
 };
 
 /* Allocates ChannelCredential instances.
@@ -114,7 +115,7 @@ VALUE grpc_rb_wrap_channel_credentials(grpc_channel_credentials* c,
   TypedData_Get_Struct(rb_wrapper, grpc_rb_channel_credentials,
                        &grpc_rb_channel_credentials_data_type, wrapper);
   wrapper->wrapped = c;
-  wrapper->mark = mark;
+  RB_OBJ_WRITE(rb_wrapper, &wrapper->mark, mark);
   return rb_wrapper;
 }
 

--- a/src/ruby/ext/grpc/rb_compression_options.c
+++ b/src/ruby/ext/grpc/rb_compression_options.c
@@ -80,9 +80,7 @@ static rb_data_type_t grpc_rb_compression_options_data_type = {
      {NULL, NULL}},
     NULL,
     NULL,
-#ifdef RUBY_TYPED_FREE_IMMEDIATELY
     RUBY_TYPED_FREE_IMMEDIATELY
-#endif
 };
 
 /* Allocates CompressionOptions instances.

--- a/src/ruby/ext/grpc/rb_grpc.c
+++ b/src/ruby/ext/grpc/rb_grpc.c
@@ -57,9 +57,7 @@ static rb_data_type_t grpc_rb_timespec_data_type = {
      {NULL, NULL}},
     NULL,
     NULL,
-#ifdef RUBY_TYPED_FREE_IMMEDIATELY
     RUBY_TYPED_FREE_IMMEDIATELY
-#endif
 };
 
 /* Alloc func that blocks allocation of a given object by raising an

--- a/src/ruby/ext/grpc/rb_server.c
+++ b/src/ruby/ext/grpc/rb_server.c
@@ -116,13 +116,11 @@ static const rb_data_type_t grpc_rb_server_data_type = {
      {NULL, NULL}},
     NULL,
     NULL,
-#ifdef RUBY_TYPED_FREE_IMMEDIATELY
     /* It is unsafe to specify RUBY_TYPED_FREE_IMMEDIATELY because the free
      * function would block and we might want to unlock GVL
      * TODO(yugui) Unlock GVL?
      */
     0,
-#endif
 };
 
 /* Allocates grpc_rb_server instances. */

--- a/src/ruby/ext/grpc/rb_server_credentials.c
+++ b/src/ruby/ext/grpc/rb_server_credentials.c
@@ -87,9 +87,7 @@ static const rb_data_type_t grpc_rb_server_credentials_data_type = {
      {NULL, NULL}},
     NULL,
     NULL,
-#ifdef RUBY_TYPED_FREE_IMMEDIATELY
     RUBY_TYPED_FREE_IMMEDIATELY
-#endif
 };
 
 /* Allocates ServerCredential instances.

--- a/src/ruby/ext/grpc/rb_xds_channel_credentials.c
+++ b/src/ruby/ext/grpc/rb_xds_channel_credentials.c
@@ -83,9 +83,7 @@ static rb_data_type_t grpc_rb_xds_channel_credentials_data_type = {
      GRPC_RB_MEMSIZE_UNAVAILABLE, NULL},
     NULL,
     NULL,
-#ifdef RUBY_TYPED_FREE_IMMEDIATELY
     RUBY_TYPED_FREE_IMMEDIATELY
-#endif
 };
 
 /* Allocates ChannelCredential instances.

--- a/src/ruby/ext/grpc/rb_xds_channel_credentials.c
+++ b/src/ruby/ext/grpc/rb_xds_channel_credentials.c
@@ -40,7 +40,8 @@ static VALUE grpc_rb_cXdsChannelCredentials = Qnil;
  * provides a mark object that is used to hold references to any objects used to
  * create the credentials. */
 typedef struct grpc_rb_xds_channel_credentials {
-  /* Holder of ruby objects involved in constructing the credentials */
+  /* Holder of ruby objects involved in constructing the credentials.
+     Must be written using RB_OBJ_WRITE for proper write barriers */
   VALUE mark;
 
   /* The actual credentials */
@@ -83,7 +84,7 @@ static rb_data_type_t grpc_rb_xds_channel_credentials_data_type = {
      GRPC_RB_MEMSIZE_UNAVAILABLE, NULL},
     NULL,
     NULL,
-    RUBY_TYPED_FREE_IMMEDIATELY
+    RUBY_TYPED_FREE_IMMEDIATELY | RUBY_TYPED_WB_PROTECTED
 };
 
 /* Allocates ChannelCredential instances.
@@ -112,7 +113,7 @@ VALUE grpc_rb_xds_wrap_channel_credentials(grpc_channel_credentials* c,
   TypedData_Get_Struct(rb_wrapper, grpc_rb_xds_channel_credentials,
                        &grpc_rb_xds_channel_credentials_data_type, wrapper);
   wrapper->wrapped = c;
-  wrapper->mark = mark;
+  RB_OBJ_WRITE(rb_wrapper, &wrapper->mark, mark);
   return rb_wrapper;
 }
 

--- a/src/ruby/ext/grpc/rb_xds_server_credentials.c
+++ b/src/ruby/ext/grpc/rb_xds_server_credentials.c
@@ -85,9 +85,7 @@ static const rb_data_type_t grpc_rb_xds_server_credentials_data_type = {
      GRPC_RB_MEMSIZE_UNAVAILABLE, NULL},
     NULL,
     NULL,
-#ifdef RUBY_TYPED_FREE_IMMEDIATELY
     RUBY_TYPED_FREE_IMMEDIATELY
-#endif
 };
 
 /* Allocates ServerCredential instances.


### PR DESCRIPTION
Add missing write barriers to address segfaults like this:

```cpp
#6  0x00007a6207b32556 in sigsegv (sig=11, info=0x7a61cd138870, ctx=0x7a61cd138740) at signal.c:933
#7  0x00007a62074ea520 in <signal handler called> () at /lib/x86_64-linux-gnu/libc.so.6
#8  0x00007a6207b74717 in hash_table_index (key=<optimized out>, tbl=<optimized out>) at /tmp/ruby-build/ruby-3.4.2-pshopify3/id_table.c:132
#9  rb_id_table_lookup (tbl=tbl@entry=0x4, id=id@entry=282833, valp=valp@entry=0x7a611b64d960) at /tmp/ruby-build/ruby-3.4.2-pshopify3/id_table.c:230
#10 0x00007a6207bc04d7 in vm_search_cc (ci=0x450d100140005, klass=134554211975520) at /tmp/ruby-build/ruby-3.4.2-pshopify3/vm_insnhelper.c:2087
#11 rb_vm_search_method_slowpath (ci=0x450d100140005, klass=134554211975520) at /tmp/ruby-build/ruby-3.4.2-pshopify3/vm_insnhelper.c:2189
#12 0x00007a6207bd08ea in vm_search_method_slowpath0 (klass=<optimized out>, cd=<optimized out>, cd_owner=<optimized out>) at /tmp/ruby-build/ruby-3.4.2-pshopify3/vm_insnhelper.c:2210
#13 vm_search_method_fastpath (klass=<optimized out>, cd=<optimized out>, cd_owner=<optimized out>) at /tmp/ruby-build/ruby-3.4.2-pshopify3/vm_insnhelper.c:2271
#14 vm_sendish (method_explorer=<optimized out>, block_handler=<optimized out>, cd=<optimized out>, reg_cfp=<optimized out>, ec=<optimized out>) at /tmp/ruby-build/ruby-3.4.2-pshopify3/vm_insnhelper.c:5960
#15 vm_exec_core (ec=0x4) at /tmp/ruby-build/ruby-3.4.2-pshopify3/insns.def:898
#16 0x00007a6207bd7a1a in rb_vm_exec (ec=0x7a60dc1f39d0) at vm.c:2595
#17 0x00007a6207bd7fc3 in invoke_iseq_block_from_c (me=0x0, is_lambda=<optimized out>, cref=0x0, passed_block_handler=0, kw_splat=<optimized out>, argv=<optimized out>, argc=<optimized out>, self=<optimized out>, captured=<optimized out>, ec=<optimized out>) at vm.c:1625
#18 0x00007a6207bd8a1f in rb_vm_invoke_proc (ec=ec@entry=0x7a60dc1f39d0, proc=<optimized out>, argc=<optimized out>, argv=argv@entry=0x7a611b64de40, kw_splat=<optimized out>, passed_block_handler=<optimized out>) at vm.c:1770
#19 0x00007a6207bdd7d8 in vm_call0_body (ec=0x7a60dc1f39d0, calling=0x7a611b64dd80, argv=0x7a611b64de40) at /tmp/ruby-build/ruby-3.4.2-pshopify3/vm_eval.c:293
#20 0x00007a6207be268e in vm_call0_cc (kw_splat=0, cc=<optimized out>, argv=0x7a611b64de40, argc=1, id=3457, recv=134554228753520, ec=0x7a60dc1f39d0) at /tmp/ruby-build/ruby-3.4.2-pshopify3/vm_eval.c:101
#21 rb_funcallv_scope (scope=CALL_FCALL, argv=0x7a611b64de40, argc=1, mid=3457, recv=134554228753520) at /tmp/ruby-build/ruby-3.4.2-pshopify3/vm_eval.c:1047
#22 rb_funcallv (recv=recv@entry=134554228753520, mid=3457, argc=argc@entry=1, argv=argv@entry=0x7a611b64de40) at /tmp/ruby-build/ruby-3.4.2-pshopify3/vm_eval.c:1062
#23 0x00007a61df04bf46 in grpc_rb_call_credentials_callback (args=args@entry=134555288032520) at /usr/local/ruby/include/ruby-3.4.0/ruby/internal/symbol.h:304
```

where we end up trying to call methods on `T_NONE` objects

```
(gdb) rp klass
T_NONE: $41 = (struct RBasic *) 0x7a6058020160
```